### PR TITLE
Add Docker Compose restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.5'
 services:
   solr:
     image: solr:6.6.5
+    restart: unless-stopped
     ports:
       - 8983:8983
     volumes:
@@ -11,6 +12,7 @@ services:
 
   postgres:
     image: postgres:14.3
+    restart: unless-stopped
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -24,6 +26,7 @@ services:
 
   redis:
     image: redis:7.0.11-alpine
+    restart: unless-stopped
     command: redis-server --save 60 1 --loglevel warning
     volumes:
       - redis_data:/data
@@ -33,6 +36,7 @@ services:
   goorchids:
     build: .
     image: ghcr.io/jazkarta/goorchids:latest
+    restart: unless-stopped
     depends_on:
       - solr
       - postgres
@@ -51,6 +55,7 @@ services:
   worker:
     build: .
     image: ghcr.io/jazkarta/goorchids:latest
+    restart: unless-stopped
     command: python worker.py
     depends_on:
       - redis


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to the long-running Docker Compose services.

Closes #176