### PR TITLE
Show content image validation errors in admin

### DIFF
--- a/goorchids/core/admin.py
+++ b/goorchids/core/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django import forms
 from django.db import models
 import gobotany.core.admin
+from django.core.exceptions import ValidationError
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.contrib.contenttypes.admin import GenericTabularInline
 from gobotany.core.models import (Taxon, PartnerSpecies, ContentImage,
@@ -41,9 +42,56 @@ class GoOrchidTaxonGenericInlineFormset(BaseGenericInlineFormSet):
                                                                 instance=instance,
                                                                 **kw)
 
+    def clean(self):
+        super(GoOrchidTaxonGenericInlineFormset, self).clean()
+
+        for form in self.forms:
+            if not hasattr(form, 'cleaned_data'):
+                continue
+            if self._should_delete_form(form):
+                continue
+            if form.errors:
+                continue
+            if not form.has_changed():
+                continue
+
+            instance = form.instance
+            try:
+                instance.clean()
+            except ValidationError as e:
+                form.add_error(None, e)
+                raise forms.ValidationError(
+                    'Please correct the image errors below.')
+
+
+class ContentImageAdminForm(forms.ModelForm):
+    class Meta:
+        model = ContentImage
+        fields = '__all__'
+
+    def _post_clean(self):
+        try:
+            super(ContentImageAdminForm, self)._post_clean()
+        except ContentImage.image_type.RelatedObjectDoesNotExist:
+            self.add_error(
+                'image_type',
+                'This field is required when uploading an image.')
+
+    def clean(self):
+        cleaned_data = super(ContentImageAdminForm, self).clean()
+
+        image = cleaned_data.get('image')
+        if image and not cleaned_data.get('image_type'):
+            self.add_error(
+                'image_type',
+                'This field is required when uploading an image.')
+
+        return cleaned_data
+
 
 class ContentImageInline(GenericTabularInline):
     model = ContentImage
+    form = ContentImageAdminForm
     formset = GoOrchidTaxonGenericInlineFormset
 
 

--- a/goorchids/core/test_content_image_admin.py
+++ b/goorchids/core/test_content_image_admin.py
@@ -1,0 +1,71 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from gobotany.core import models as gobotany_models
+from goorchids.core.admin import ContentImageAdminForm
+
+
+class ContentImageAdminFormTests(TestCase):
+
+    def test_missing_image_type_is_a_form_error(self):
+        image = SimpleUploadedFile(
+            'test.gif',
+            b'GIF87a\x01\x00\x01\x00\x80\x01\x00\x00\x00\x00'
+            b'\xff\xff\xff,\x00\x00\x00\x00\x01\x00\x01\x00'
+            b'\x00\x02\x02D\x01\x00;',
+            content_type='image/gif')
+        form = ContentImageAdminForm(data={
+            'alt': 'Stem detail',
+            'rank': 1,
+            'creator': 'test-photographer',
+        }, files={
+            'image': image,
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('image_type', form.errors)
+
+
+class ContentImageModelValidationTests(TestCase):
+
+    def setUp(self):
+        self.family = gobotany_models.Family.objects.create(
+            name='Orchidaceae',
+            common_name='orchid family')
+        self.genus = gobotany_models.Genus.objects.create(
+            name='Example',
+            common_name='example genus',
+            family=self.family)
+        self.taxon = gobotany_models.Taxon.objects.create(
+            scientific_name='Example orchid',
+            family=self.family,
+            genus=self.genus,
+            taxonomic_authority='Tester')
+        self.image_type = gobotany_models.ImageType.objects.create(
+            name='habit')
+        self.content_type = ContentType.objects.get_for_model(
+            gobotany_models.Taxon)
+
+    def test_duplicate_canonical_image_raises_validation_error(self):
+        gobotany_models.ContentImage.objects.create(
+            alt='First',
+            rank=1,
+            creator='test-photographer',
+            image_type=self.image_type,
+            content_type=self.content_type,
+            object_id=self.taxon.id)
+
+        image = gobotany_models.ContentImage(
+            alt='Second',
+            rank=1,
+            creator='test-photographer',
+            image_type=self.image_type,
+            content_type=self.content_type,
+            object_id=self.taxon.id)
+
+        with self.assertRaisesMessage(
+                ValidationError,
+                'There is already a canonical (rank 1) habit image'):
+            image.clean()


### PR DESCRIPTION
## Summary
- surface missing image type and duplicate canonical image validation errors in the taxon admin form
- add focused admin validation coverage

Fixes #174