### PR TITLE
Hide empty values on the species page

### DIFF
--- a/goorchids/site/templates/gobotany/species.html
+++ b/goorchids/site/templates/gobotany/species.html
@@ -84,16 +84,14 @@
       {% endif %}
       </section>
 
+      {% if taxon.factoid.strip %}
       <section class="content-area">
         <h2>Facts About</h2>
         <p>
-            {% if taxon.factoid|length > 0 %}
-                {{ taxon.factoid.strip|linebreaksbr }}
-            {% else %}
-                N/A
-            {% endif %}
+            {{ taxon.factoid.strip|linebreaksbr }}
         </p>
       </section>
+      {% endif %}
 
       {% if taxon.pollination %}
       <section class="content-area">
@@ -215,73 +213,40 @@
 
         <div id="conservation-status">
             <h4>Conservation Status</h4>
+            {% if conservation_status_tables %}
             <form>
                 <p>Select a location to view conservation status:</p>
                 <select id="region-switcher">
                     <option value="">Enter state or province</option>
-                {% for conservation_status in taxon.regional_conservation_statuses.all %}
-                    <option value="{{conservation_status.region}}">{{conservation_status.get_region_display}}</option>
+                {% for table in conservation_status_tables %}
+                    {% if table.region %}
+                    <option value="{{table.region}}">{{table.region_name}}</option>
+                    {% endif %}
                 {% endfor %}
                 </select>
             </form>
-            <table class="conservation-status" data-region="">
+            {% for table in conservation_status_tables %}
+            <table class="conservation-status{% if table.region %} hidden{% endif %}" data-region="{{table.region}}">
                 <thead>
                     <tr>
                         <th></th>
-                        <th>Conservation and Wetland Status</th>
+                        <th>{{table.heading}}</th>
                     </tr>
                 </thead>
                 <tbody>
+                {% for row in table.rows %}
                     <tr>
-                        <th>Global Rank</th>
-                        <td>{{taxon.get_global_rank_display|default_if_none:"N/A"}}</td>
+                        <th>{{row.label}}</th>
+                        <td>{{row.value}}</td>
                     </tr>
-                    <tr>
-                        <th>US Status</th>
-                        <td>{{taxon.get_us_status_display|default_if_none:"N/A"}}</td>
-                    </tr>
-                    <tr>
-                        <th>Canadian Status</th>
-                        <td>{{taxon.get_ca_rank_display|default_if_none:"N/A"}}</td>
-                    </tr>
+                {% endfor %}
                 </tbody>
             </table>
-        {% for conservation_status in taxon.regional_conservation_statuses.all %}
-        <table class="conservation-status hidden" data-region="{{conservation_status.region}}">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>Conservation status for: {{conservation_status.get_region_display}}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <th>Global Rank</th>
-                    <td>{{taxon.get_global_rank_display|default_if_none:"N/A"}}</td>
-                </tr>
-                <tr>
-                    <th>US Status</th>
-                    <td>{{taxon.get_us_status_display|default_if_none:"N/A"}}</td>
-                </tr>
-                <tr>
-                    <th>{{conservation_status.get_region_display}} Rank</th>
-                    <td>{{conservation_status.get_rank_display|default_if_none:"N/A"}}</td>
-                </tr>
-                <tr>
-                    <th>{{conservation_status.get_region_display}} Status</th>
-                    <td>{{conservation_status.get_status_display|default_if_none:"N/A"}}</td>
-                </tr>
-                <tr>
-                    <th>Canadian Status</th>
-                    <td>{{taxon.get_ca_rank_display|default_if_none:"N/A"}}</td>
-                </tr>
-                <tr>
-                    <th>Wetland Status</th>
-                    <td>{{conservation_status.get_wetland_status_display|default_if_none:"N/A"}}</td>
-                </tr>
-            </tbody>
-        </table>
-        {% endfor %}
+            {% endfor %}
+            {% else %}
+            <p>No conservation status information is available for this
+                species.</p>
+            {% endif %}
         </div>
 
         <div class="map namap">

--- a/goorchids/site/tests/test_species_conservation_status.py
+++ b/goorchids/site/tests/test_species_conservation_status.py
@@ -1,0 +1,126 @@
+from django.test import TestCase
+
+from gobotany.core import models as gobotany_models
+
+from goorchids.core.models import GoOrchidTaxon, RegionalConservationStatus
+
+
+class SpeciesPageTestCase(TestCase):
+
+    def setUp(self):
+        self.family = gobotany_models.Family.objects.create(
+            name='Orchidaceae',
+            common_name='orchid family')
+        self.genus = gobotany_models.Genus.objects.create(
+            name='Dendrophylax',
+            common_name='ghost orchid',
+            family=self.family)
+        self.taxon = GoOrchidTaxon.objects.create(
+            scientific_name='Dendrophylax lindenii',
+            family=self.family,
+            genus=self.genus,
+            taxonomic_authority='Tester',
+            ready_for_display=True)
+        pilegroup = gobotany_models.PileGroup.objects.create(
+            name='Monocots',
+            slug='monocots')
+        pile = gobotany_models.Pile.objects.create(
+            name='Orchid monocots',
+            slug='orchid-monocots',
+            pilegroup=pilegroup)
+        self.taxon.piles.add(pile)
+
+    def get_species_page(self):
+        response = self.client.get('/species/dendrophylax/lindenii/')
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode('utf-8')
+
+
+class ConservationStatusDisplayTests(SpeciesPageTestCase):
+
+    def test_ranks_without_a_value_are_left_out(self):
+        self.taxon.global_rank = 'G3'
+        self.taxon.save()
+
+        page = self.get_species_page()
+
+        self.assertIn('Global Rank', page)
+        self.assertIn('Vulnerable', page)
+        self.assertNotIn('US Status', page)
+        self.assertNotIn('Canadian Status', page)
+        self.assertNotIn('N/A', page)
+
+    def test_regional_statuses_without_a_value_are_left_out(self):
+        self.taxon.global_rank = 'G3'
+        self.taxon.save()
+        RegionalConservationStatus.objects.create(
+            taxon=self.taxon,
+            region='fl',
+            status='E')
+
+        page = self.get_species_page()
+
+        self.assertIn('Conservation status for: Florida', page)
+        self.assertIn('Florida Status', page)
+        self.assertIn('Endangered', page)
+        self.assertNotIn('Florida Rank', page)
+        self.assertNotIn('<th>Wetland Status</th>', page)
+        self.assertNotIn('N/A', page)
+
+    def test_a_species_without_any_status_shows_no_table(self):
+        page = self.get_species_page()
+
+        self.assertNotIn('<table class="conservation-status', page)
+        self.assertNotIn('region-switcher', page)
+        self.assertIn('No conservation status information is available',
+                      page)
+        self.assertNotIn('N/A', page)
+
+    def test_a_region_without_any_status_is_not_offered(self):
+        RegionalConservationStatus.objects.create(
+            taxon=self.taxon,
+            region='fl')
+
+        page = self.get_species_page()
+
+        self.assertNotIn('Florida', page)
+        self.assertNotIn('N/A', page)
+
+    def test_statuses_that_have_a_value_are_still_shown(self):
+        self.taxon.global_rank = 'G3'
+        self.taxon.us_status = 'LE'
+        self.taxon.ca_rank = '1'
+        self.taxon.save()
+        RegionalConservationStatus.objects.create(
+            taxon=self.taxon,
+            region='fl',
+            status='E',
+            rank='S1',
+            wetland_status='FACW')
+
+        page = self.get_species_page()
+
+        for expected in ('Vulnerable', 'Listed Endangered', 'At Risk',
+                         'Endangered', 'Highly State Rare',
+                         'Facultative Wetland'):
+            self.assertIn(expected, page)
+        self.assertIn('<option value="fl">Florida</option>', page)
+        self.assertNotIn('N/A', page)
+
+
+class FactsAboutDisplayTests(SpeciesPageTestCase):
+
+    def test_facts_about_is_left_out_when_empty(self):
+        page = self.get_species_page()
+
+        self.assertNotIn('Facts About', page)
+        self.assertNotIn('N/A', page)
+
+    def test_facts_about_is_shown_when_present(self):
+        self.taxon.factoid = 'Grows without leaves.'
+        self.taxon.save()
+
+        page = self.get_species_page()
+
+        self.assertIn('Facts About', page)
+        self.assertIn('Grows without leaves.', page)

--- a/goorchids/site/views.py
+++ b/goorchids/site/views.py
@@ -302,6 +302,64 @@ def _compare_character_values(a, b):
     return 0  # default value (no sort)
 
 
+def _conservation_status_rows(taxon, conservation_status=None):
+    """Build the rows of one conservation status table.
+
+    Rows without a value are left out, so that the species page does not
+    display rows of "N/A" for the many taxa that have no rank or status
+    for a given jurisdiction.
+    """
+    rows = [
+        ('Global Rank', taxon.get_global_rank_display()),
+        ('US Status', taxon.get_us_status_display()),
+    ]
+    if conservation_status is not None:
+        region_name = conservation_status.get_region_display()
+        rows.append(('%s Rank' % region_name,
+                     conservation_status.get_rank_display()))
+        rows.append(('%s Status' % region_name,
+                     conservation_status.get_status_display()))
+    rows.append(('Canadian Status', taxon.get_ca_rank_display()))
+    if conservation_status is not None:
+        rows.append(('Wetland Status',
+                     conservation_status.get_wetland_status_display()))
+
+    return [{'label': label, 'value': value} for label, value in rows
+            if value]
+
+
+def _conservation_status_tables(taxon):
+    """Build the conservation status tables for a species page.
+
+    The first table holds the statuses that apply everywhere, and is the
+    one shown before a region is selected; the rest hold the statuses for
+    a single region. A table with no rows to show is left out entirely.
+    """
+    tables = []
+
+    rows = _conservation_status_rows(taxon)
+    if rows:
+        tables.append({
+            'region': '',
+            'region_name': '',
+            'heading': 'Conservation and Wetland Status',
+            'rows': rows,
+        })
+
+    for conservation_status in taxon.regional_conservation_statuses.all():
+        rows = _conservation_status_rows(taxon, conservation_status)
+        if rows:
+            region_name = conservation_status.get_region_display()
+            tables.append({
+                'region': conservation_status.region,
+                'region_name': region_name,
+                'heading': 'Conservation status for: %s' % region_name,
+                'rows': rows,
+            })
+
+    return tables
+
+
 def species_view(request, genus_slug, epithet):
 
     COMPACT_MULTIVALUE_CHARACTERS = ['Habitat', 'New England state',
@@ -422,7 +480,8 @@ def species_view(request, genus_slug, epithet):
         'brief_characteristics': preview_characters,
         'all_characteristics': all_characteristics,
         'epithet': epithet,
-        'native_to_north_america': native_to_north_america
+        'native_to_north_america': native_to_north_america,
+        'conservation_status_tables': _conservation_status_tables(taxon),
     })
 
 


### PR DESCRIPTION
This PR proposes hiding the empty "N/A" rows on the species page so that only conservation statuses that actually have a value are displayed (Fixes #111). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/276. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

Every species page rendered a fixed set of conservation status rows, filling in `N/A` wherever the taxon had no value — the `default_if_none:"N/A"` filters on the global rank, US status, Canadian status, regional rank, regional status and wetland status cells in `goorchids/site/templates/gobotany/species.html`. The "Facts About" section did the same for taxa with no factoid. This is visible on the site right now — the Ghost Orchid page renders five of them:

```
$ curl -s https://goorchids.northamericanorchidcenter.org/species/dendrophylax/lindenii/ | grep -c '<td>N/A</td>'
5
```

A related detail: the region switcher was built from every `RegionalConservationStatus` row, so a region whose record carries no rank, status or wetland value still appeared in the drop-down and selected an all-`N/A` table.

## The change

`species_view` now builds the conservation status tables it hands to the template (`_conservation_status_tables`), in the same spirit as the character-group structures it already assembles. A row is included only when it has a value, a table is included only when it has rows, and the region drop-down is built from the tables that survive, so a region with nothing to show is no longer offered. The template renders that structure instead of a fixed grid of cells. When a taxon has no conservation status at all, the section says so in one line rather than showing a table of `N/A`. Rows that do have values keep their existing labels, order and markup — including the `data-region` attributes and the `hidden` class that `orchid_site/species.js` toggles — so the region switcher behaves exactly as before. The "Facts About" section is now omitted when the factoid is empty instead of printing `N/A`.

## Verifying it

Reproduced on `master` at `f882c27` with the new tests in place and the fix reverted:

```
$ docker compose exec -e PYTHONDONTWRITEBYTECODE=1 goorchids python manage.py test goorchids.site
FAIL: test_ranks_without_a_value_are_left_out
AssertionError: 'US Status' unexpectedly found in ... <th>US Status</th>\n<td>N/A</td>
FAILED (failures=6)
```

Six of the seven new tests fail on the unmodified tree; the seventh is the control that asserts a populated "Facts About" section still renders, and stays green either way. With the change applied they all pass, and the project suite goes from 3 tests to 10 with no new failures:

```
$ docker compose exec -e PYTHONDONTWRITEBYTECODE=1 goorchids python manage.py test
Ran 10 tests in 0.290s
OK
```

The tests live in `goorchids/site/tests/`, following the package layout adopted for `goorchids/core/tests/` in #183. They drive the real species URL through the test client and cover: ranks with no value dropped, regional statuses with no value dropped, a species with no status at all, a region that has nothing to show being left out of the switcher, every populated status still rendering (with the `<option value="fl">Florida</option>` markup intact), and the "Facts About" section in both states.

## How this was managed

This work was tracked as a story on a board imported from this repository's own issues and pull requests — 181 stories and 6 labels: [Hide N/A values on the Species page](https://eastagiletracker.com/projects/276/stories/163305), on the [Go Orchids board](https://eastagiletracker.com/projects/276).

![board](https://raw.githubusercontent.com/eastagiletracker/goorchids-app/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
